### PR TITLE
Add getEncoder method to access encoder instance

### DIFF
--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -48,6 +48,14 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
       new BinaryMessageDecoder<${this.mangle($schema.getName())}>(MODEL$, SCHEMA$);
 
   /**
+   * Return the BinaryMessageEncoder instance used by this class.
+   * @return the message encoder used by this class
+   */
+  public static BinaryMessageEncoder<${this.mangle($schema.getName())}> getEncoder() {
+    return ENCODER;
+  }
+  
+  /**
    * Return the BinaryMessageDecoder instance used by this class.
    * @return the message decoder used by this class
    */


### PR DESCRIPTION
Would like to add the getEncoder method to the generated classes

Unless the encoder should be protected not sure why there is access to the decoder and not the encoder. If there is a better way to get a BinaryMessageEncoder for this schemaStore let me know.